### PR TITLE
Add mobile-optimized dashboard with bottom navigation

### DIFF
--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -374,7 +374,7 @@ export default function AIChat({
       {showFloatingButton && (
         <Button
           onClick={() => setIsOpen(true)}
-          className="fixed bottom-6 right-6 h-14 w-14 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 shadow-lg transition-transform hover:scale-110 z-40"
+          className="fixed right-4 lg:right-6 bottom-[calc(env(safe-area-inset-bottom)+4.5rem)] lg:bottom-6 h-14 w-14 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 shadow-lg transition-transform hover:scale-110 z-50"
           aria-label="Open chat"
         >
           <MessageCircle className="h-6 w-6 text-white" />
@@ -391,7 +391,7 @@ export default function AIChat({
                 : isFullScreen
                   ? "fixed inset-0 z-50 p-0 bg-background overscroll-none touch-none"
                   : variant === "floating"
-                    ? "fixed bottom-6 right-6 z-50"
+                    ? "fixed right-4 lg:right-6 bottom-[calc(env(safe-area-inset-bottom)+4.5rem)] lg:bottom-6 z-50"
                     : "relative z-auto mt-6",
           )}
         >

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -92,11 +92,7 @@ async function tryResetBackend(accessToken?: string | null) {
   }
 
   // 2) Fallback: send a reset command payload to chat endpoints
-  const payloads = [
-    { action: "reset" },
-    { reset: true },
-    { command: "reset" },
-  ];
+  const payloads = [{ action: "reset" }, { reset: true }, { command: "reset" }];
   for (const url of getCandidateApiUrls()) {
     for (const body of payloads) {
       try {
@@ -500,9 +496,15 @@ export default function AIChat({
                       </div>
                       {m.role === "user" && (
                         <Avatar className="mt-1 h-8 w-8">
-                          <AvatarImage src={user?.avatar || undefined} alt={user?.name || user?.email || "User"} />
+                          <AvatarImage
+                            src={user?.avatar || undefined}
+                            alt={user?.name || user?.email || "User"}
+                          />
                           <AvatarFallback className="bg-gray-500 text-white text-xs font-medium">
-                            {getInitials(user?.name || null, user?.email || null)}
+                            {getInitials(
+                              user?.name || null,
+                              user?.email || null,
+                            )}
                           </AvatarFallback>
                         </Avatar>
                       )}

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -156,7 +156,9 @@ export default function Layout({ children }: LayoutProps) {
               onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
               className={cn(
                 "absolute hidden lg:flex w-8 h-8 rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-business hover:shadow-business-md transition-all duration-300 hover:scale-110",
-                sidebarCollapsed ? "right-0 translate-x-1/2 top-4" : "-right-4 top-6",
+                sidebarCollapsed
+                  ? "right-0 translate-x-1/2 top-4"
+                  : "-right-4 top-6",
               )}
             >
               <Menu
@@ -428,7 +430,11 @@ export default function Layout({ children }: LayoutProps) {
               { href: "/warehouse", icon: Package, label: "Warehouse" },
               { href: "/clients", icon: Users, label: "Clients" },
               { href: "/sales", icon: ShoppingCart, label: "Sales" },
-              { href: "/settings", icon: Settings, label: t("navigation.settings") },
+              {
+                href: "/settings",
+                icon: Settings,
+                label: t("navigation.settings"),
+              },
             ].map((item) => {
               const active = location.pathname === item.href;
               const Icon = item.icon;

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -125,7 +125,7 @@ export default function Layout({ children }: LayoutProps) {
 
   useEffect(() => {
     if (openChat) {
-      const params = new URLSearchParams(searchParams as any);
+      const params = new URLSearchParams(searchParams);
       params.delete("chat");
       const qs = params.toString();
       navigate(`${location.pathname}${qs ? `?${qs}` : ""}`, { replace: true });

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -471,7 +471,11 @@ export default function Layout({ children }: LayoutProps) {
       </div>
 
       {/* Global floating AI Chat (hidden on Chat page) */}
-      <AIChat variant="floating" defaultOpen={openChat} showTrigger={location.pathname !== "/chat"} />
+      <AIChat
+        variant="floating"
+        defaultOpen={openChat}
+        showTrigger={location.pathname !== "/chat"}
+      />
 
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Link, useLocation, useSearchParams } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -49,6 +49,7 @@ import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import AvatarUpload from "@/components/AvatarUpload";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import AIChat from "@/components/AIChat";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -65,6 +66,8 @@ export default function Layout({ children }: LayoutProps) {
   const { toast } = useToast();
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const openChat = searchParams.get("chat") === "open";
 
   const allNavigation = [
     {
@@ -119,6 +122,15 @@ export default function Layout({ children }: LayoutProps) {
       if (sidebarOpen) setSidebarOpen(false);
     }
   };
+
+  useEffect(() => {
+    if (openChat) {
+      const params = new URLSearchParams(searchParams as any);
+      params.delete("chat");
+      const qs = params.toString();
+      navigate(`${location.pathname}${qs ? `?${qs}` : ""}`, { replace: true });
+    }
+  }, [openChat]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -457,6 +469,9 @@ export default function Layout({ children }: LayoutProps) {
           </nav>
         </footer>
       </div>
+
+      {/* Global floating AI Chat (hidden on Chat page) */}
+      <AIChat variant="floating" defaultOpen={openChat} showTrigger={location.pathname !== "/chat"} />
 
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -418,7 +418,38 @@ export default function Layout({ children }: LayoutProps) {
         </header>
 
         {/* Page content - mobile-optimized padding */}
-        <main className="p-4 md:p-6">{children}</main>
+        <main className="p-4 pb-24 md:p-6 md:pb-6">{children}</main>
+
+        {/* Mobile bottom navigation */}
+        <footer className="fixed inset-x-0 bottom-0 z-40 border-t border-gray-200/60 dark:border-gray-700/60 bg-white/90 dark:bg-gray-900/90 backdrop-blur supports-[backdrop-filter]:bg-white/60 lg:hidden">
+          <nav className="grid grid-cols-5 h-16">
+            {[
+              { href: "/dashboard", icon: LayoutDashboard, label: "Dashboard" },
+              { href: "/warehouse", icon: Package, label: "Warehouse" },
+              { href: "/clients", icon: Users, label: "Clients" },
+              { href: "/sales", icon: ShoppingCart, label: "Sales" },
+              { href: "/settings", icon: Settings, label: t("navigation.settings") },
+            ].map((item) => {
+              const active = location.pathname === item.href;
+              const Icon = item.icon;
+              return (
+                <Link
+                  key={item.href}
+                  to={item.href}
+                  className={cn(
+                    "flex flex-col items-center justify-center gap-1 text-xs font-medium",
+                    active
+                      ? "text-primary"
+                      : "text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white",
+                  )}
+                >
+                  <Icon className={cn("h-5 w-5", active && "text-primary")} />
+                  <span className="truncate max-w-[68px]">{item.label}</span>
+                </Link>
+              );
+            })}
+          </nav>
+        </footer>
       </div>
 
       {/* Mobile sidebar overlay */}

--- a/client/components/ui/card.tsx
+++ b/client/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-4 sm:p-6", className)}
     {...props}
   />
 ));
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-4 sm:p-6 pt-0", className)} {...props} />
 ));
 CardContent.displayName = "CardContent";
 

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -47,7 +47,7 @@ import UserCredentials from "@/components/UserCredentials";
 import { useAuthStore } from "@/stores/authStore";
 import { API_BASE } from "@/lib/api";
 import { SalesSummaryResponse } from "@shared/api";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 const salesData = [
   { name: "Jan", sales: 4000, profit: 2400 },
@@ -61,15 +61,6 @@ const salesData = [
 export default function Dashboard() {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
-  const [searchParams] = useSearchParams();
-  const openChat = searchParams.get("chat") === "open";
-
-  // If chat was opened via URL, clean the param so refresh doesn't auto-open
-  useEffect(() => {
-    if (openChat) {
-      navigate("/dashboard", { replace: true });
-    }
-  }, [openChat, navigate]);
   const { toast } = useToast();
   const { t } = useTranslation();
   const { user } = useAuthStore();

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -31,7 +31,6 @@ import {
   TrendingDown,
   AlertTriangle,
   ShoppingCart,
-  MessageCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
@@ -49,7 +48,6 @@ import { useAuthStore } from "@/stores/authStore";
 import { API_BASE } from "@/lib/api";
 import { SalesSummaryResponse } from "@shared/api";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import AIChat from "@/components/AIChat";
 
 const salesData = [
   { name: "Jan", sales: 4000, profit: 2400 },
@@ -1770,17 +1768,6 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
         </Card>
       )}
 
-      {/* Floating chat panel, opened via URL param */}
-      <AIChat variant="floating" defaultOpen={openChat} showTrigger={false} />
-
-      {/* Corner AI button opens full-screen chat page */}
-      <Button
-        onClick={() => navigate("/chat")}
-        className="fixed bottom-6 right-6 h-14 w-14 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 shadow-lg transition-transform hover:scale-110 z-40"
-        aria-label="Open AI Chat"
-      >
-        <MessageCircle className="h-6 w-6 text-white" />
-      </Button>
     </div>
   );
 }

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1758,7 +1758,6 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
           </CardContent>
         </Card>
       )}
-
     </div>
   );
 }

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1140,7 +1140,7 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
 
       {/* Enhanced KPI Cards with Glassmorphism */}
       <div className="grid gap-4 md:gap-6 [grid-auto-columns:85%] grid-flow-col overflow-x-auto snap-x snap-mandatory sm:[grid-auto-columns:initial] sm:grid-flow-row md:grid-cols-2 lg:grid-cols-4">
-        <Card className="relative overflow-hidden group border-0 bg-gradient-to-br from-white via-white to-green-50/30 backdrop-blur-xl shadow-business-lg hover:shadow-business-xl transition-all duration-500 hover:scale-[1.02] hover:-translate-y-1">
+        <Card className="snap-start relative overflow-hidden group border-0 bg-gradient-to-br from-white via-white to-green-50/30 backdrop-blur-xl shadow-business-lg hover:shadow-business-xl transition-all duration-500 hover:scale-[1.02] hover:-translate-y-1">
           <div className="absolute inset-0 bg-gradient-to-br from-green-500/5 to-emerald-500/10 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4 relative z-10">
             <CardTitle className="text-sm font-semibold text-gray-700 tracking-tight">
@@ -1195,7 +1195,7 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden group border-0 bg-gradient-to-br from-white via-white to-blue-50/30 backdrop-blur-xl shadow-business-lg hover:shadow-business-xl transition-all duration-500 hover:scale-[1.02] hover:-translate-y-1">
+        <Card className="snap-start relative overflow-hidden group border-0 bg-gradient-to-br from-white via-white to-blue-50/30 backdrop-blur-xl shadow-business-lg hover:shadow-business-xl transition-all duration-500 hover:scale-[1.02] hover:-translate-y-1">
           <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-cyan-500/10 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4 relative z-10">
             <CardTitle className="text-sm font-semibold text-gray-700 tracking-tight">
@@ -1245,7 +1245,7 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden group border-0 bg-gradient-to-br from-white via-white to-purple-50/30 backdrop-blur-xl shadow-business-lg hover:shadow-business-xl transition-all duration-500 hover:scale-[1.02] hover:-translate-y-1">
+        <Card className="snap-start relative overflow-hidden group border-0 bg-gradient-to-br from-white via-white to-purple-50/30 backdrop-blur-xl shadow-business-lg hover:shadow-business-xl transition-all duration-500 hover:scale-[1.02] hover:-translate-y-1">
           <div className="absolute inset-0 bg-gradient-to-br from-purple-500/5 to-pink-500/10 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4 relative z-10">
             <CardTitle className="text-sm font-semibold text-gray-700 tracking-tight">
@@ -1295,7 +1295,7 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
           </CardContent>
         </Card>
 
-        <Card className="relative overflow-hidden group border-0 bg-gradient-to-br from-white via-white to-orange-50/30 backdrop-blur-xl shadow-business-lg hover:shadow-business-xl transition-all duration-500 hover:scale-[1.02] hover:-translate-y-1">
+        <Card className="snap-start relative overflow-hidden group border-0 bg-gradient-to-br from-white via-white to-orange-50/30 backdrop-blur-xl shadow-business-lg hover:shadow-business-xl transition-all duration-500 hover:scale-[1.02] hover:-translate-y-1">
           <div className="absolute inset-0 bg-gradient-to-br from-orange-500/5 to-red-500/10 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4 relative z-10">
             <CardTitle className="text-sm font-semibold text-gray-700 tracking-tight">

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1602,26 +1602,29 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
               </div>
               <div className="w-full overflow-x-auto">
                 <Table className="min-w-[640px]">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>
-                      {t("warehouse.product_name") || "Product"}
-                    </TableHead>
-                    <TableHead className="text-right">
-                      {t("dashboard.products_sold")}
-                    </TableHead>
-                    <TableHead className="text-right">
-                      {t("finance.sales_revenue")}
-                    </TableHead>
-                    <TableHead className="text-right">
-                      {t("finance.profit")}
-                    </TableHead>
-                    <TableHead className="text-right">Margin %</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {(derivedSales?.products || salesSummary?.products || []).map(
-                    (p) => {
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>
+                        {t("warehouse.product_name") || "Product"}
+                      </TableHead>
+                      <TableHead className="text-right">
+                        {t("dashboard.products_sold")}
+                      </TableHead>
+                      <TableHead className="text-right">
+                        {t("finance.sales_revenue")}
+                      </TableHead>
+                      <TableHead className="text-right">
+                        {t("finance.profit")}
+                      </TableHead>
+                      <TableHead className="text-right">Margin %</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(
+                      derivedSales?.products ||
+                      salesSummary?.products ||
+                      []
+                    ).map((p) => {
                       const margin =
                         p.revenue && p.profit != null
                           ? (p.profit / p.revenue) * 100
@@ -1647,10 +1650,9 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
                           </TableCell>
                         </TableRow>
                       );
-                    },
-                  )}
-                </TableBody>
-              </Table>
+                    })}
+                  </TableBody>
+                </Table>
               </div>
             </>
           )}

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useIsMobile } from "@/hooks/use-mobile";
 import {
   Card,
   CardContent,
@@ -61,6 +62,7 @@ const salesData = [
 
 export default function Dashboard() {
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const [searchParams] = useSearchParams();
   const openChat = searchParams.get("chat") === "open";
 
@@ -1124,20 +1126,20 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
   };
 
   return (
-    <div className="space-y-8 animate-fade-in">
+    <div className="space-y-6 sm:space-y-8 animate-fade-in">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-6 border-b border-border">
         <div className="space-y-2">
-          <h1 className="text-4xl font-bold tracking-tight bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
+          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
             {t("dashboard.title")}
           </h1>
-          <p className="text-muted-foreground text-lg">
+          <p className="text-muted-foreground text-sm sm:text-base lg:text-lg">
             {t("dashboard.subtitle")}
           </p>
         </div>
       </div>
 
       {/* Enhanced KPI Cards with Glassmorphism */}
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 md:gap-6 [grid-auto-columns:85%] grid-flow-col overflow-x-auto snap-x snap-mandatory sm:[grid-auto-columns:initial] sm:grid-flow-row md:grid-cols-2 lg:grid-cols-4">
         <Card className="relative overflow-hidden group border-0 bg-gradient-to-br from-white via-white to-green-50/30 backdrop-blur-xl shadow-business-lg hover:shadow-business-xl transition-all duration-500 hover:scale-[1.02] hover:-translate-y-1">
           <div className="absolute inset-0 bg-gradient-to-br from-green-500/5 to-emerald-500/10 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4 relative z-10">
@@ -1371,7 +1373,7 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
             <div className="text-sm text-red-600">{cashFlowError}</div>
           )}
           {!cashFlowLoading && !cashFlowError && (
-            <ResponsiveContainer width="100%" height={320}>
+            <ResponsiveContainer width="100%" height={isMobile ? 220 : 320}>
               <LineChart
                 data={cashFlowData}
                 margin={{ top: 10, right: 20, left: 0, bottom: 0 }}
@@ -1431,7 +1433,7 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
             </div>
           </CardHeader>
           <CardContent>
-            <ResponsiveContainer width="100%" height={300}>
+            <ResponsiveContainer width="100%" height={isMobile ? 220 : 300}>
               <BarChart data={computedSalesData}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" />
@@ -1464,7 +1466,7 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
             </div>
           </CardHeader>
           <CardContent>
-            <ResponsiveContainer width="100%" height={300}>
+            <ResponsiveContainer width="100%" height={isMobile ? 220 : 300}>
               <PieChart>
                 <Pie
                   data={categoryDist}
@@ -1598,7 +1600,8 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
                   </div>
                 </div>
               </div>
-              <Table>
+              <div className="w-full overflow-x-auto">
+                <Table className="min-w-[640px]">
                 <TableHeader>
                   <TableRow>
                     <TableHead>
@@ -1648,6 +1651,7 @@ ${data.recentActivities.map((activity: any) => `${activity.time} - ${activity.de
                   )}
                 </TableBody>
               </Table>
+              </div>
             </>
           )}
         </CardContent>

--- a/public/icons/app-icon.svg
+++ b/public/icons/app-icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#2563eb" />
+      <stop offset="1" stop-color="#7c3aed" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="url(#g)" />
+  <g fill="#fff">
+    <path d="M20 40c0-8.837 7.163-16 16-16h8v8h-8a8 8 0 0 0-8 8z" opacity=".9"/>
+    <path d="M44 24c0 8.837-7.163 16-16 16h-8v-8h8a8 8 0 0 0 8-8z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Purpose

The user requested a mobile-specific version of the dashboard, noting that the current mobile experience was just a scaled-down desktop version. They wanted a proper mobile PWA experience with dedicated mobile UI components and layout optimizations.

## Code changes

- **Mobile bottom navigation**: Added fixed bottom navigation bar with 5 main sections (Dashboard, Warehouse, Clients, Sales, Settings) that only appears on mobile devices
- **Responsive layout improvements**: 
  - Updated main content padding to account for bottom navigation (`pb-24` on mobile)
  - Made KPI cards horizontally scrollable on mobile with snap scrolling
  - Reduced chart heights on mobile (220px vs 320px/300px on desktop)
  - Added responsive text sizing for dashboard title and subtitle
- **Card component optimization**: Reduced padding on mobile (`p-4` vs `p-6` on desktop)
- **Table responsiveness**: Added horizontal scroll wrapper for product sales table
- **PWA icon**: Added app icon SVG for better mobile app experience
- **Mobile-first spacing**: Adjusted grid gaps and spacing throughout for better mobile UXTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/93fab82e80f543d3a07848aa805c3be7/echo-forge)

👀 [Preview Link](https://93fab82e80f543d3a07848aa805c3be7-echo-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>93fab82e80f543d3a07848aa805c3be7</projectId>-->
<!--<branchName>echo-forge</branchName>-->